### PR TITLE
core(trace-processor): use new toplevel task event name (#5841)

### DIFF
--- a/lighthouse-core/lib/traces/tracing-processor.js
+++ b/lighthouse-core/lib/traces/tracing-processor.js
@@ -8,8 +8,12 @@
 // The ideal input response latency, the time between the input task and the
 // first frame of the response.
 const BASE_RESPONSE_LATENCY = 16;
+// m65 and earlier
 const SCHEDULABLE_TASK_TITLE = 'TaskQueueManager::ProcessTaskFromWorkQueue';
-const SCHEDULABLE_TASK_TITLE_ALT = 'ThreadControllerImpl::DoWork';
+// In m66-68 refactored to this task title, https://crrev.com/c/883346
+const SCHEDULABLE_TASK_TITLE_ALT1 = 'ThreadControllerImpl::DoWork';
+// m69+ DoWork is different and we now need RunTask, see https://bugs.chromium.org/p/chromium/issues/detail?id=871204#c11
+const SCHEDULABLE_TASK_TITLE_ALT2 = 'ThreadControllerImpl::RunTask';
 const LHError = require('../errors');
 
 class TraceProcessor {
@@ -222,7 +226,9 @@ class TraceProcessor {
    * @return {boolean}
    */
   static isScheduleableTask(evt) {
-    return evt.name === SCHEDULABLE_TASK_TITLE || evt.name === SCHEDULABLE_TASK_TITLE_ALT;
+    return evt.name === SCHEDULABLE_TASK_TITLE ||
+      evt.name === SCHEDULABLE_TASK_TITLE_ALT1 ||
+      evt.name === SCHEDULABLE_TASK_TITLE_ALT2;
   }
 }
 

--- a/lighthouse-core/scripts/lantern/minify-trace.js
+++ b/lighthouse-core/scripts/lantern/minify-trace.js
@@ -34,6 +34,7 @@ const inputTrace = JSON.parse(inputTraceRaw);
 const toplevelTaskNames = new Set([
   'TaskQueueManager::ProcessTaskFromWorkQueue',
   'ThreadControllerImpl::DoWork',
+  'ThreadControllerImpl::RunTask',
 ]);
 
 const traceEventsToAlwaysKeep = new Set([


### PR DESCRIPTION
Sample pr messsage